### PR TITLE
Fixed mandatory qaTag for ST_PAGE_TITLE components

### DIFF
--- a/src/app/modules/examples/examples.template.html
+++ b/src/app/modules/examples/examples.template.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
    <div class="row">
       <div class="col-lg-24 col-md-24 col-sm-24 col-xs-24">
-         <st-page-title title="{{ 'GLOBAL.EXAMPLES' | translate }}"></st-page-title>
+         <st-page-title title="{{ 'GLOBAL.EXAMPLES' | translate }}" qaTag="title"></st-page-title>
       </div>
    </div>
    <br />

--- a/src/app/modules/resources/resources.template.html
+++ b/src/app/modules/resources/resources.template.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
    <div class="row center">
       <div class="col-lg-20 col-md-24 col-sm-24 col-xs-24">
-         <st-page-title title="{{ 'GLOBAL.RESOURCES' | translate }}"></st-page-title>
+         <st-page-title title="{{ 'GLOBAL.RESOURCES' | translate }}" qaTag="title"></st-page-title>
       </div>
    </div>
    <br />


### PR DESCRIPTION
The most recent SNAPSHOT of egeo includes a new attribute qaTag for <st-page-title/> components. The tag had to be included in the starter project.